### PR TITLE
Switch to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 notifications:
   email: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   - ANT_ARGS="-logger org.apache.tools.ant.listener.AnsiColorLogger -Dnet.furfurylic.chionographis.squelch=true"
 script:


### PR DESCRIPTION
Now we migrate to openjdk8 from oraclejdk8 in Travis CI build checking.