### PR TITLE
Employ an explicit source-highlighter attribute entry

### DIFF
--- a/doc/UsersGuide.asciidoc
+++ b/doc/UsersGuide.asciidoc
@@ -1,5 +1,6 @@
 = Chionographis User's Guide
 :revnumber:, :revdate:
+:source-highlighter: pygments
 
 == Overview
 


### PR DESCRIPTION
Make `source-highliter = pygments` attribute entry appear in the asciidoc of the user's guide explicitly.

This is not likely to break builds even in environments without pygments.