### PR TITLE
Add supports of relative URIs to <meta>

### DIFF
--- a/doc/UsersGuide.asciidoc
+++ b/doc/UsersGuide.asciidoc
@@ -224,6 +224,7 @@ In this regard, _Chinographis_ driver synchronizes accesses to _XMLCatalogs_ add
 
 |type|The type of the meta-information, which is the data of PI.  +
 When +uri+, the data shall be the absolute URI of the original source. +
+When +relative-uri+, the data shall be the relative URI of the original source to the base directory to the task. +
 When +file-name+, the data shall be the last part of the path of the URI. +
 When +file-title+, the data shall be the substring of the file name before its last period (+.+).| Yes
 |=================

--- a/src/net/furfurylic/chionographis/Chionographis.java
+++ b/src/net/furfurylic/chionographis/Chionographis.java
@@ -503,8 +503,9 @@ public final class Chionographis extends MatchingTask implements Driver {
     }
 
     private List<Map.Entry<String, Function<URI, String>>> createMetaFuncs() {
+        final URI baseURI = baseDir_.toAbsolutePath().toUri();
         List<Map.Entry<String, Function<URI, String>>> metaFuncs =
-            metas_.getList().stream().map(Meta::yield).collect(Collectors.toList());
+            metas_.getList().stream().map(m -> m.yield(baseURI)).collect(Collectors.toList());
         metaFuncs.forEach(e -> logger_.log(this,
                     "Adding a meta-information instruction: name=" + e.getKey(), Level.DEBUG));
         return metaFuncs;

--- a/test/basic/input-meta/expected.txt
+++ b/test/basic/input-meta/expected.txt
@@ -1,1 +1,1 @@
-[input:<chionographis-file-name=input.xml><chionographis-file-title=input>[child:]]
+[input:<chionographis-file-name=input.xml><chionographis-file-title=input><chionographis-relative-uri=basic/input-meta/input.xml>[child:]]

--- a/test/test.xml
+++ b/test/test.xml
@@ -879,6 +879,7 @@
     <chionographis srcdir="${dir.input}" includes="*.xml" cache="no">
       <meta type="file-name"/>
       <meta type="file-title"/>
+      <meta type="relative-uri"/>
       <output dest="${dir.output}/output.xml"/>
     </chionographis>
 


### PR DESCRIPTION
As reported in #197, it is not very convinient that `<meta>`s cannot be configured to emit relative URIs. This patch make them able to be configured to do it.

The base URI that the relative URIs are resolved to is the base URI of the task. This base URI should be configured for each `<meta>`, but this patch does not reach that far.