### PR TITLE
Make <meta> able to be configured with the base URI

### DIFF
--- a/doc/UsersGuide.asciidoc
+++ b/doc/UsersGuide.asciidoc
@@ -224,9 +224,12 @@ In this regard, _Chinographis_ driver synchronizes accesses to _XMLCatalogs_ add
 
 |type|The type of the meta-information, which is the data of PI.  +
 When +uri+, the data shall be the absolute URI of the original source. +
-When +relative-uri+, the data shall be the relative URI of the original source to the base directory to the task. +
+When +relative-uri+, the data shall be the relative URI of the original source to the base URI specified by _baseURI_ attribute. +
 When +file-name+, the data shall be the last part of the path of the URI. +
 When +file-title+, the data shall be the substring of the file name before its last period (+.+).| Yes
+
+|baseURI|The base URI to relativize the URI of the original source. +
+This attribute is meaningful only when _type_ attribute is configured to be +relative-uri+.| No; defaulted to the base directory of the task
 |=================
 
 ===== Namespace element's attributes

--- a/src/net/furfurylic/chionographis/Chionographis.java
+++ b/src/net/furfurylic/chionographis/Chionographis.java
@@ -503,9 +503,8 @@ public final class Chionographis extends MatchingTask implements Driver {
     }
 
     private List<Map.Entry<String, Function<URI, String>>> createMetaFuncs() {
-        final URI baseURI = baseDir_.toAbsolutePath().toUri();
         List<Map.Entry<String, Function<URI, String>>> metaFuncs =
-            metas_.getList().stream().map(m -> m.yield(baseURI)).collect(Collectors.toList());
+            metas_.getList().stream().map(m -> m.yield(baseDir_.toFile())).collect(Collectors.toList());
         metaFuncs.forEach(e -> logger_.log(this,
                     "Adding a meta-information instruction: name=" + e.getKey(), Level.DEBUG));
         return metaFuncs;

--- a/src/net/furfurylic/chionographis/Meta.java
+++ b/src/net/furfurylic/chionographis/Meta.java
@@ -7,6 +7,7 @@
 
 package net.furfurylic.chionographis;
 
+import java.io.File;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -36,11 +37,15 @@ public final class Meta extends ProjectComponent {
             }
         },
 
-        /** The relative URI. The corresponding string expression is "relative-uri". */
+        /**
+         * The relative URI. The corresponding string expression is "relative-uri".
+         *
+         * @since 1.3
+         */
         RELATIVE_URI {
             @Override
             Function<java.net.URI, String> extractor(java.net.URI baseURI) {
-                return (java.net.URI u) -> baseURI.relativize(u).toString();
+                return u -> baseURI.relativize(u).toString();
             }
          },
 
@@ -99,6 +104,7 @@ public final class Meta extends ProjectComponent {
 
     private Type type_ = null;
     private String name_ = null;
+    private String baseURI_ = null;
 
     /**
      * Sole constructor.
@@ -149,10 +155,25 @@ public final class Meta extends ProjectComponent {
     }
 
     /**
-     * Creates a key-value pair from this object's content.
+     * Sets the base URI to relativize URIs of the original sources.
+     *
+     * <p>This base URI is meaningful only when "relative-uri" is set
+     * with {@link #setType(String)}.</p>
      *
      * @param baseURI
-     *      the base URI to relativize URIs.
+     *      the base URI.
+     *
+     * @since 1.3
+     */
+    public void setBaseURI(String baseURI) {
+        baseURI_ = baseURI;
+    }
+
+    /**
+     * Creates a key-value pair from this object's content.
+     *
+     * @param baseDir
+     *      the base directory to relativize URIs.
      *
      * @return
      *      a key-value pair for this object's content, which shall not be {@code null}.
@@ -162,7 +183,7 @@ public final class Meta extends ProjectComponent {
      * @throws BuildException
      *      if the {@linkplain #setType(String) type} is not set.
      */
-    Map.Entry<String, Function<java.net.URI, String>> yield(java.net.URI baseURI) {
+    Map.Entry<String, Function<java.net.URI, String>> yield(File baseDir) {
         if (type_ == null) {
             String message = "Incomplete meta-information instruction found";
             if (name_ != null) {
@@ -175,6 +196,8 @@ public final class Meta extends ProjectComponent {
         if (name_ == null) {
             name = type_.defaultName();
         }
+        final java.net.URI baseURI = (baseURI_ != null) ?
+            URIUtils.getAbsoluteURI(baseURI_, baseDir) : baseDir.toURI();
         return new AbstractMap.SimpleImmutableEntry<>(name, type_.extractor(baseURI));
     }
 }

--- a/src/net/furfurylic/chionographis/Transform.java
+++ b/src/net/furfurylic/chionographis/Transform.java
@@ -9,7 +9,6 @@ package net.furfurylic.chionographis;
 
 import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
@@ -190,26 +189,12 @@ public final class Transform extends Filter {
     void doInit(File baseDir, NamespaceContext namespaceContext, boolean dryRun) {
         paramMap_ = createParamMap(namespaceContext);
 
-        Function<String, URI> getAbsoluteURI = s -> {
-            URI uri = null;
-            try {
-                // First we try as a URI
-                uri = new URI(s);
-            } catch (URISyntaxException e) {
-                // Second we try as a file
-            }
-            if ((uri == null) || !uri.isAbsolute()) {
-                uri = baseDir.toPath().resolve(s).toUri();
-            }
-            return uri;
-        };
-
         if (style_ != null) {
             getAbsoluteURI_ = null;
-            URI absoluteURI = getAbsoluteURI.apply(style_);
+            URI absoluteURI = URIUtils.getAbsoluteURI(style_, baseDir);
             stylesheetLocation_ = new StylesheetLocation(absoluteURI, depends_, logger());
         } else {
-            getAbsoluteURI_ = getAbsoluteURI;
+            getAbsoluteURI_ = s -> URIUtils.getAbsoluteURI(s, baseDir);
             stylesheetLocation_ = null;
         }
 

--- a/src/net/furfurylic/chionographis/URIUtils.java
+++ b/src/net/furfurylic/chionographis/URIUtils.java
@@ -1,0 +1,25 @@
+package net.furfurylic.chionographis;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+final class URIUtils {
+
+    private URIUtils() {
+    }
+
+    public static URI getAbsoluteURI(String s, File baseDir) {
+        URI uri = null;
+        try {
+            // First we try as a URI
+            uri = new URI(s);
+        } catch (URISyntaxException e) {
+            // Second we try as a file
+        }
+        if ((uri == null) || !uri.isAbsolute()) {
+            uri = baseDir.toPath().resolve(s).toUri();
+        }
+        return uri;
+    }
+}

--- a/test/basic/input-meta/expected.txt
+++ b/test/basic/input-meta/expected.txt
@@ -1,1 +1,1 @@
-[input:<chionographis-file-name=input.xml><chionographis-file-title=input><chionographis-relative-uri=basic/input-meta/input.xml>[child:]]
+[input:<chionographis-file-name=input.xml><chionographis-file-title=input><chionographis-relative-uri=basic/input-meta/input.xml><rel=input.xml>[child:]]

--- a/test/test.xml
+++ b/test/test.xml
@@ -880,6 +880,7 @@
       <meta type="file-name"/>
       <meta type="file-title"/>
       <meta type="relative-uri"/>
+      <meta type="relative-uri" baseuri="${dir.input}" name="rel"/>
       <output dest="${dir.output}/output.xml"/>
     </chionographis>
 


### PR DESCRIPTION
Literally. Now `<meta>` can have an attribute named `baseURI`, which is used to relativize the URIs of the original sources.